### PR TITLE
Add/remove CSS class to fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,8 @@
 
 All Notable changes to `client-side-validation` will be documented in this file
 
+## 1.1.0
+- Add/remove CSS class to fields
+
 ## 1.0.0
 - Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-side-validation",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Client side form validation",
   "main": "lib/index.js",
   "scripts": {

--- a/src/inputHandlers.js
+++ b/src/inputHandlers.js
@@ -42,10 +42,12 @@ const getInputError = $input => {
 };
 
 export const clearInputError = $input => {
+    $input.removeClass('$validation-error');
     getInputError($input).text('');
 };
 
 export const setInputError = ($input, error) => {
+    $input.addClass('$validation-error');
     getInputError($input).text(parseMessage(error[0], error[1]));
 };
 


### PR DESCRIPTION
This commit adds/removes CSS class `$validation-error` to an input field on validation. 
The field can now be styled eg. with a red border when validation fails.
